### PR TITLE
fix: broken links outside of the docs

### DIFF
--- a/docs/org/1.1 Summary.md
+++ b/docs/org/1.1 Summary.md
@@ -18,4 +18,4 @@ All of this is achieved with strictly plain text files, the most portable and fu
 
 There is a website for Org which provides links to the newest version of Org, as well as additional information, frequently asked questions (FAQ), links to tutorials, etc. This page is located at [https://orgmode.org](https://orgmode.org).
 
-An earlier version (7.3) of this manual is available as a [paperback book from Network Theory Ltd.](/docs/org/http://www.network-theory.co.uk/org/manual/).
+An earlier version (7.3) of this manual is available as a [paperback book from Network Theory Ltd.](http://www.network-theory.co.uk/org/manual/).

--- a/docs/org/12.5.1 LaTeX fragments.md
+++ b/docs/org/12.5.1 LaTeX fragments.md
@@ -2,7 +2,7 @@
 slug: LaTeX-fragments
 ---
 
-Org mode can contain LaTeX math fragments, and it supports ways to process these for several export back-ends. When exporting to LaTeX, the code is left as it is. When exporting to HTML, Org can use either [MathJax](/docs/org/http://www.mathjax.org) (see [Math formatting in HTML export](/docs/org/Math-formatting-in-HTML-export)) or transcode the math into images (see [Previewing LaTeX fragments](/docs/org/Previewing-LaTeX-fragments)).
+Org mode can contain LaTeX math fragments, and it supports ways to process these for several export back-ends. When exporting to LaTeX, the code is left as it is. When exporting to HTML, Org can use either [MathJax](http://www.mathjax.org) (see [Math formatting in HTML export](/docs/org/Math-formatting-in-HTML-export)) or transcode the math into images (see [Previewing LaTeX fragments](/docs/org/Previewing-LaTeX-fragments)).
 
 LaTeX fragments do not need any special marking at all. The following snippets are identified as LaTeX source code:
 

--- a/docs/org/12.5.2 Previewing LaTeX fragments.md
+++ b/docs/org/12.5.2 Previewing LaTeX fragments.md
@@ -24,4 +24,4 @@ To disable it, simply use
 #+STARTUP: nolatexpreview
 ```
 
-[^1]: These are respectively available at [http://sourceforge.net/projects/dvipng/](/docs/org/http://sourceforge.net/projects/dvipng/), [http://dvisvgm.bplaced.net/](/docs/org/http://dvisvgm.bplaced.net/) and from the ImageMagick suite. Choose the converter by setting the variable `org-preview-latex-default-process` accordingly.
+[^1]: These are respectively available at [http://sourceforge.net/projects/dvipng/](http://sourceforge.net/projects/dvipng/), [http://dvisvgm.bplaced.net/](http://dvisvgm.bplaced.net/) and from the ImageMagick suite. Choose the converter by setting the variable `org-preview-latex-default-process` accordingly.

--- a/docs/org/13.10.6 Images in LaTeX export.md
+++ b/docs/org/13.10.6 Images in LaTeX export.md
@@ -2,7 +2,7 @@
 slug: Images-in-LaTeX-export
 ---
 
-The LaTeX export back-end processes image links in Org files that do not have descriptions, such as these links ‘`[[file:img.jpg]]`’ or ‘`[[./img.jpg]]`’, as direct image insertions in the final PDF output. In the PDF, they are no longer links but actual images embedded on the page. The LaTeX export back-end uses ‘`\includegraphics`’ macro to insert the image. But for TikZ ([http://sourceforge.net/projects/pgf/](/docs/org/http://sourceforge.net/projects/pgf/)) images, the back-end uses an `\input` macro wrapped within a `tikzpicture` environment.
+The LaTeX export back-end processes image links in Org files that do not have descriptions, such as these links ‘`[[file:img.jpg]]`’ or ‘`[[./img.jpg]]`’, as direct image insertions in the final PDF output. In the PDF, they are no longer links but actual images embedded on the page. The LaTeX export back-end uses ‘`\includegraphics`’ macro to insert the image. But for TikZ ([http://sourceforge.net/projects/pgf/](http://sourceforge.net/projects/pgf/)) images, the back-end uses an `\input` macro wrapped within a `tikzpicture` environment.
 
 For specifying image ‘`:width`’, ‘`:height`’, ‘`:scale`’ and other ‘`:options`’, use this syntax:
 

--- a/docs/org/13.11 Markdown Export.md
+++ b/docs/org/13.11 Markdown Export.md
@@ -2,7 +2,7 @@
 slug: Markdown-Export
 ---
 
-The Markdown export back-end, “md", converts an Org file to Markdown format, as defined at [http://daringfireball.net/projects/markdown/](/docs/org/http://daringfireball.net/projects/markdown/).
+The Markdown export back-end, “md", converts an Org file to Markdown format, as defined at [http://daringfireball.net/projects/markdown/](http://daringfireball.net/projects/markdown/).
 
 Since it is built on top of the HTML back-end (see [HTML Export](/docs/org/HTML-Export)), it converts every Org construct not defined in Markdown syntax, such as tables, to HTML.
 

--- a/docs/org/13.12 OpenDocument Text Export.md
+++ b/docs/org/13.12 OpenDocument Text Export.md
@@ -19,4 +19,4 @@ The ODT export back-end handles creating of OpenDocument Text (ODT) format. Docu
 | • [Literal examples in ODT export](/docs/org/Literal-examples-in-ODT-export)       |    | For source code and example blocks. |
 | • [Advanced topics in ODT export](/docs/org/Advanced-topics-in-ODT-export)         |    | For power users.                    |
 
-[^1]: See [Open Document Format for Office Applications (OpenDocument) Version 1.2](/docs/org/http://docs.oasis-open.org/office/v1.2/OpenDocument-v1.2.html).
+[^1]: See [Open Document Format for Office Applications (OpenDocument) Version 1.2](http://docs.oasis-open.org/office/v1.2/OpenDocument-v1.2.html).

--- a/docs/org/13.12.12 Advanced topics in ODT export.md
+++ b/docs/org/13.12.12 Advanced topics in ODT export.md
@@ -221,7 +221,7 @@ Sometimes ODT format files may not open due to ‘`.odt`’ file corruption. To 
 
 Customize `org-odt-schema-dir` to point to a directory with OpenDocument RNC files and the needed schema-locating rules. The ODT export back-end takes care of updating the `rng-schema-locating-files`.
 
-[^1]: [OpenDocument-v1.2 Specification](/docs/org/http://docs.oasis-open.org/office/v1.2/OpenDocument-v1.2.html)
+[^1]: [OpenDocument-v1.2 Specification](https://docs.oasis-open.org/office/v1.2/OpenDocument-v1.2.html)
 
 [^2]: See the ‘`<table:table-template>`’ element of the OpenDocument-v1.2 specification.
 

--- a/docs/org/13.12.9 Math formatting in ODT export.md
+++ b/docs/org/13.12.9 Math formatting in ODT export.md
@@ -70,9 +70,9 @@ or
 
 Under this option, LaTeX fragments are processed into PNG or SVG images and the resulting images are embedded in the exported document. This method requires dvipng program, dvisvgm or ImageMagick programs.
 
-[^1]: See [MathToWeb](/docs/org/http://www.mathtoweb.com/cgi-bin/mathtoweb_home.pl).
+[^1]: See [MathToWeb](http://www.mathtoweb.com/cgi-bin/mathtoweb_home.pl).
 
-[^2]: See [http://dlmf.nist.gov/LaTeXML/](/docs/org/http://dlmf.nist.gov/LaTeXML/).
+[^2]: See [http://dlmf.nist.gov/LaTeXML/](http://dlmf.nist.gov/LaTeXML/).
 ## 13.12.9.2 MathML and OpenDocument formula files
 
 When embedding LaTeX math snippets in ODT documents is not reliable, there is one more option to try. Embed an equation by linking to its MathML (‘`.mml`’) source or its OpenDocument formula (‘`.odf`’) file as shown below:

--- a/docs/org/13.9.10 Math formatting in HTML export.md
+++ b/docs/org/13.9.10 Math formatting in HTML export.md
@@ -2,7 +2,7 @@
 slug: Math-formatting-in-HTML-export
 ---
 
-LaTeX math snippets (see [LaTeX fragments](/docs/org/LaTeX-fragments)) can be displayed in two different ways on HTML pages. The default is to use the [MathJax](/docs/org/http://www.mathjax.org), which should work out of the box with Org[^1][^2]. Some MathJax display options can be configured via `org-html-mathjax-options`, or in the buffer. For example, with the following settings,
+LaTeX math snippets (see [LaTeX fragments](/docs/org/LaTeX-fragments)) can be displayed in two different ways on HTML pages. The default is to use the [MathJax](http://www.mathjax.org), which should work out of the box with Org[^1][^2]. Some MathJax display options can be configured via `org-html-mathjax-options`, or in the buffer. For example, with the following settings,
 
 ```lisp
 #+HTML_MATHJAX: align: left indent: 5em tagside: left font: Neo-Euler
@@ -29,8 +29,8 @@ or
 #+OPTIONS: tex:imagemagick
 ```
 
-[^1]: By default Org loads MathJax from [cdnjs.com](https://cdnjs.com) as recommended by [MathJax](/docs/org/http://www.mathjax.org).
+[^1]: By default Org loads MathJax from [cdnjs.com](https://cdnjs.com) as recommended by [MathJax](http://www.mathjax.org).
 
 [^2]: Please note that exported formulas are part of an HTML document, and that signs such as ‘`<`’, ‘`>`’, or ‘`&`’ have special meanings. See [MathJax TeX and LaTeX support](/docs/org/tex-and-latex-in-html-documents).
 
-[^3]: See [TeX and LaTeX extensions](/docs/org/tex-extensions) in the [MathJax manual](/docs/org/http://docs.mathjax.org) to learn about extensions.
+[^3]: See [TeX and LaTeX extensions](/docs/org/tex-extensions) in the [MathJax manual](http://docs.mathjax.org) to learn about extensions.

--- a/docs/org/15.11 Noweb Reference Syntax.md
+++ b/docs/org/15.11 Noweb Reference Syntax.md
@@ -202,4 +202,4 @@ When in doubt about the outcome of a source code block expansion, you can previe
 
 Expand the current source code block according to its header arguments and pop open the results in a preview buffer.
 
-[^1]: For noweb literate programming details, see [http://www.cs.tufts.edu/\~nr/noweb/](/docs/org/http://www.cs.tufts.edu/\~nr/noweb/).
+[^1]: For noweb literate programming details, see [http://www.cs.tufts.edu/\~nr/noweb/](http://www.cs.tufts.edu/\~nr/noweb/).

--- a/docs/org/16.13.1 Packages that Org cooperates with.md
+++ b/docs/org/16.13.1 Packages that Org cooperates with.md
@@ -8,7 +8,7 @@ Org uses the Calc package for implementing spreadsheet functionality in its tabl
 
 ### ‘`constants.el`’ by Carsten Dominik
 
-Org can use names for constants in formulas in tables. Org can also use calculation suffixes for units, such as ‘`M`’ for ‘`Mega`’. For a standard collection of such constants, install the ‘`constants`’ package. Install version 2.0 of this package, available at [http://www.astro.uva.nl/\~dominik/Tools](/docs/org/http://www.astro.uva.nl/\~dominik/Tools). Org checks if the function `constants-get` has been autoloaded. Installation instructions are in the file ‘`constants.el`’.
+Org can use names for constants in formulas in tables. Org can also use calculation suffixes for units, such as ‘`M`’ for ‘`Mega`’. For a standard collection of such constants, install the ‘`constants`’ package. Install version 2.0 of this package, available at [http://www.astro.uva.nl/\~dominik/Tools](http://www.astro.uva.nl/\~dominik/Tools). Org checks if the function `constants-get` has been autoloaded. Installation instructions are in the file ‘`constants.el`’.
 
 ### ‘`cdlatex.el`’ by Carsten Dominik
 

--- a/docs/org/3.6 Org Plot.md
+++ b/docs/org/3.6 Org Plot.md
@@ -6,7 +6,7 @@ Org Plot can produce graphs of information stored in Org tables, either graphica
 
 ## Graphical plots using Gnuplot
 
-Org Plot can produce 2D and 3D graphs of information stored in Org tables using [Gnuplot](/docs/org/http://www.gnuplot.info/) and [Gnuplot mode](/docs/org/http://cars9.uchicago.edu/\~ravel/software/gnuplot-mode.html). To see this in action, ensure that you have both Gnuplot and Gnuplot mode installed on your system, then call `C-c " g` or `M-x org-plot/gnuplot` on the following table.
+Org Plot can produce 2D and 3D graphs of information stored in Org tables using [Gnuplot](http://www.gnuplot.info/) and [Gnuplot mode](http://cars9.uchicago.edu/\~ravel/software/gnuplot-mode.html). To see this in action, ensure that you have both Gnuplot and Gnuplot mode installed on your system, then call `C-c " g` or `M-x org-plot/gnuplot` on the following table.
 
 ```lisp
 #+PLOT: title:"Citas" ind:1 deps:(3) type:2d with:histograms set:"yrange [0:]"

--- a/docs/org/C GNU Free Documentation License.md
+++ b/docs/org/C GNU Free Documentation License.md
@@ -126,7 +126,7 @@ of this license document, but changing it is not allowed.
 
 10. FUTURE REVISIONS OF THIS LICENSE
 
-    The Free Software Foundation may publish new, revised versions of the GNU Free Documentation License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns. See [http://www.gnu.org/copyleft/](/docs/org/http://www.gnu.org/copyleft/).
+    The Free Software Foundation may publish new, revised versions of the GNU Free Documentation License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns. See [http://www.gnu.org/copyleft/](http://www.gnu.org/copyleft/).
 
     Each version of the License is given a distinguishing version number. If the Document specifies that a particular numbered version of this License “or any later version" applies to it, you have the option of following the terms and conditions either of that specified version or of any later version that has been published (not as a draft) by the Free Software Foundation. If the Document does not specify a version number of this License, you may choose any version ever published (not as a draft) by the Free Software Foundation. If the Document specifies that a proxy can decide which future versions of this License can be used, that proxy’s public statement of acceptance of a version permanently authorizes you to choose that version for the Document.
 


### PR DESCRIPTION
Going through the orgmode documentations I've seen some links that were outside of the docs and still got the prefix `/docs/org/` which made them break. Seems like https://github.com/tefkah/emacs-docs/commit/d22763cdfa1d207281b4bcd84cdb7805717d2fbf did introduce that to some links, the ones in the PR here were all the broken ones I found for the orgmode docs.